### PR TITLE
Adds an at_exit hook in order to flush the queue upon finishing the c…

### DIFF
--- a/lib/stenotype/adapters/base.rb
+++ b/lib/stenotype/adapters/base.rb
@@ -35,11 +35,24 @@ module Stenotype
       #
       # This method is expected to be implemented by subclasses
       # @abstract
-      # @raise [NotImplementedError] unless implemented in a subclass
+      # @raise {NotImplementedError} unless implemented in a subclass
       #
       def publish(_event_data, **_additional_attrs)
         raise NotImplementedError,
               "#{self.class.name} must implement method #publish"
+      end
+
+      #
+      # This method is expected to be implemented by subclasses. In case async
+      # publisher is used the process might end before the async queue of
+      # messages is processed, so this method is going to be used in a
+      # `at_exit` hook to flush the queue.
+      # @abstract
+      # @raise {NotImplementedError} unless implemented in a subclass
+      #
+      def flush!
+        raise NotImplementedError,
+              "#{self.class.name} must implement method #flush"
       end
     end
   end

--- a/lib/stenotype/adapters/google_cloud.rb
+++ b/lib/stenotype/adapters/google_cloud.rb
@@ -56,6 +56,16 @@ module Stenotype
         end
       end
 
+      #
+      # Flushes the topic's async queue
+      #
+      def flush!
+        # a publisher might be uninitialized until the first event is published
+        return unless topic.async_publisher
+
+        topic.async_publisher.stop.wait!
+      end
+
       private
 
       def publish_sync(event_data, **additional_attrs)

--- a/lib/stenotype/adapters/stdout_adapter.rb
+++ b/lib/stenotype/adapters/stdout_adapter.rb
@@ -40,6 +40,13 @@ module Stenotype
         end
       end
 
+      #
+      # Does nothing
+      #
+      def flush!
+        # noop
+      end
+
       private
 
       def client

--- a/lib/stenotype/at_exit.rb
+++ b/lib/stenotype/at_exit.rb
@@ -1,0 +1,8 @@
+require 'stenotype'
+
+# :nocov:
+at_exit do
+  targets = Stenotype.config.targets
+  targets.each(&:flush!)
+end
+# :nocov:

--- a/spec/stenotype/adapters/base_spec.rb
+++ b/spec/stenotype/adapters/base_spec.rb
@@ -3,11 +3,11 @@
 require "spec_helper"
 
 RSpec.describe Stenotype::Adapters::Base do
-  describe "#publish" do
-    let(:klass) { Class.new(described_class) }
-    let(:klass_instance) { klass.new }
-    let(:event_data) { object_double(:event_data) }
+  let(:klass) { Class.new(described_class) }
+  let(:klass_instance) { klass.new }
+  let(:event_data) { object_double(:event_data) }
 
+  describe "#publish" do
     subject(:publish) { klass_instance.publish(event_data) }
 
     context "when not implemented" do
@@ -28,6 +28,31 @@ RSpec.describe Stenotype::Adapters::Base do
 
       it "does not raise" do
         expect(publish).to eq(true)
+      end
+    end
+  end
+
+  describe "#flush" do
+    subject(:flush!) { klass_instance.flush! }
+
+    context "when not implemented" do
+      it "raises NotImplementedError" do
+        expect { flush! }.to raise_error(NotImplementedError)
+      end
+    end
+
+    context "when a subclass implements method #flush!" do
+      before do
+        klass.class_eval do
+          def flush!
+            # do nothing
+            true
+          end
+        end
+      end
+
+      it "does not raise" do
+        expect(flush!).to eq(true)
       end
     end
   end

--- a/spec/stenotype/adapters/stdout_adapter_spec.rb
+++ b/spec/stenotype/adapters/stdout_adapter_spec.rb
@@ -3,19 +3,28 @@
 require "spec_helper"
 
 RSpec.describe Stenotype::Adapters::StdoutAdapter do
+  let(:client_double) { instance_double(Logger) }
+  let(:event_data) { { event: :data } }
+  let(:additional_arguments) { { additional: :arguments } }
+
+  let(:adapter) { described_class.new(client: client_double) }
+
   describe "#publish" do
-    let(:client_double) { instance_double(Logger) }
-    let(:event_data) { { event: :data } }
-    let(:additional_arguments) { { additional: :arguments } }
-
-    subject(:adapter) { described_class.new(client: client_double) }
-
+    subject(:publish) { adapter.publish(event_data, additional_arguments) }
     before { allow(client_double).to receive(:info).and_yield }
 
     it "publishes the message to STDOUT" do
-      adapter.publish(event_data, additional_arguments)
+      publish
 
       expect(client_double).to have_received(:info).with("[Stenotype::Event] emitted with the following attributes")
+    end
+  end
+
+  describe "#flush!" do
+    subject(:flush!) { adapter.flush! }
+
+    it 'does nothing' do
+      expect(flush!).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
…lient process.

### Description

In case an event is emitted in a separate process (for example a job) the process itself might finish before an async queue is flushed, that is why we need to make sure we flush the queue before exiting the process. For example:

1. We have defined a job which is emitting an event
2. Async mode for GC is enabled
3. A separate job process starts to process the job
4. An event is added to the queue when `emit_event` is called (which is handled in a separate *publisher thread*)
5. The job finishes before the *publisher thread* finished processing of the queue
6. The queue is lost and left events are never published.

This problem is not only for the jobs, but also for the application and any client code in general. In case the application process (or in general a client process) stops before the queue is flushed then the events get lost. Having an `at_exit` hook resolves both cases.