### PR TITLE
Renames the event name field from `name` to `_event_name`

### DIFF
--- a/lib/stenotype/event_serializer.rb
+++ b/lib/stenotype/event_serializer.rb
@@ -42,7 +42,7 @@ module Stenotype
     #
     def serialize
       {
-        name: event_name,
+        _event_name: event_name,
         **event_attributes,
         **default_options,
         **eval_context_options,

--- a/spec/stenotype/emitter_spec.rb
+++ b/spec/stenotype/emitter_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
     context "when called in a regular method" do
       let(:expected_event_data) do
         {
-          name: "manual_event",
+          _event_name: "manual_event",
           class: "DummyKlass",
           method: :emit_manually,
           timestamp: Time.now.utc,
@@ -76,7 +76,7 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
     context "when called in an aliased method" do
       let(:expected_event_data) do
         {
-          name: "aliased",
+          _event_name: "aliased",
           class: "DummyKlass",
           method: :to_be_aliased,
           timestamp: Time.now.utc,
@@ -102,7 +102,7 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
     context "when being an instance method" do
       let(:expected_event_data) do
         {
-          name: "instance_method",
+          _event_name: "instance_method",
           type: "instance_method",
           class: "DummyKlass",
           method: :some_method,
@@ -121,7 +121,7 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
     context "when being a class method" do
       let(:expected_event_data) do
         {
-          name: "class_method",
+          _event_name: "class_method",
           type: "class_method",
           class: "DummyKlass",
           method: :some_class_method,

--- a/spec/stenotype/event_serializer_spec.rb
+++ b/spec/stenotype/event_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Stenotype::EventSerializer do
   describe "#serialize", type: :with_frozen_time do
     it "represents an event as a hash" do
       expect(serializer.serialize).to eq(
-        name: event_name,
+        _event_name: event_name,
         **data,
         timestamp: Time.now.utc,
         uuid: "abcd",

--- a/spec/stenotype/frameworks/rails/action_controller_extension_spec.rb
+++ b/spec/stenotype/frameworks/rails/action_controller_extension_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Stenotype::Frameworks::Rails::ActionControllerExtension do
 
       let(:expected_result) do
         {
-          name: "view",
+          _event_name: "view",
           class: "DummyController",
           ip: "0.0.0.0",
           method: "GET",
@@ -130,7 +130,7 @@ RSpec.describe Stenotype::Frameworks::Rails::ActionControllerExtension do
 
     let(:expected_result) do
       {
-        name: "view",
+        _event_name: "view",
         class: "DummyController",
         ip: "0.0.0.0",
         method: "GET",

--- a/spec/stenotype/frameworks/rails/active_job_extension_spec.rb
+++ b/spec/stenotype/frameworks/rails/active_job_extension_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Stenotype::Frameworks::Rails::ActiveJobExtension do
   let(:test_target) { Stenotype::TestAdapter.new(test_buffer) }
   let(:expected_result) do
     {
-      name: "active_job_DummyJob",
+      _event_name: "active_job_DummyJob",
       type: "active_job",
       timestamp: Time.now.utc,
       enqueued_at: Time.now.utc,


### PR DESCRIPTION
Addresses https://github.com/Freshly/stenotype/issues/19

**NOTE: UPDATE GOOGLE CLOUD FUNCTION TO REFLECT THIS CHANGE AND NOTIFY THE DATA TEAM OF THIS CHANGE!!!!**