### PR TITLE
Renames some of the designating attributes to be more specific. Adds …

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,36 @@ Stenotype::Event.emit!(
 
 The event is then going to be passed to a dispatcher responsible for sending the evens to targets. Note that a context handler must be registered before using it. See [Custom context handlers](#custom-context-handlers) for more details.
 
+**Note:**
+The second argument is available in the context handler, in such case you can refer to the keys as regular methods. There are 4 service attributes which are going to be merged into resulting hash by default: `:type, :triggered_by, :triggered_by_method, :triggered_by_class`. For example:
+```ruby
+Stenotype::Event.emit!(
+    "Event Name",
+    { symbol_key: :value1, "string_key" => :value2, type: :custom },
+    eval_context: { name_of_registered_context_handler: context_object }
+)
+
+class MyContextHandler < Stenotype::ContextHandlers::Base
+  self.handler_name = :name_of_registered_context_handler
+
+  def as_json(*_args)
+    {
+      from_context_object: context.method_on_context_object,
+      from_additional_arguments1: symbol_key, # => :value1
+      from_additional_arguments2: string_key, # => :value2
+    }
+  end
+end
+context_handler_object.as_json # =>
+# # Resulting hash:
+# {
+#    from_context_object: 'result of context.method_on_context_object',
+#    from_additional_arguments1: 'value1',
+#    from_additional_arguments2: 'value2',
+#    type: 'custom'
+# }
+```
+
 #### ActionController
 
 Upon loading the library `ActionController` is going to be extended with a class method `track_view(*actions)`, where `actions` is a list of trackable controller actions.

--- a/lib/stenotype/context_handlers/base.rb
+++ b/lib/stenotype/context_handlers/base.rb
@@ -43,6 +43,14 @@ module Stenotype
         raise NotImplementedError, "#{self} must implement method ##{__method__}"
       end
 
+      # :nodoc:
+      def method_missing(method_name, *args, &block)
+        return options[method_name] if options.has_key?(method_name)
+        return options[method_name.to_s] if options.has_key?(method_name.to_s)
+        super
+      end
+      # :nodoc:
+
       #
       # @attr_writer {Symbol} handler_name The name under which a handler is going to be registered
       #

--- a/lib/stenotype/context_handlers/rails/active_job.rb
+++ b/lib/stenotype/context_handlers/rails/active_job.rb
@@ -24,7 +24,7 @@ module Stenotype
             job_id: job_id,
             enqueued_at: Time.now.utc,
             queue_name: queue_name,
-            class: context.class.name,
+            triggered_by_class: context.class.name,
           }
         end
 

--- a/lib/stenotype/context_handlers/rails/controller.rb
+++ b/lib/stenotype/context_handlers/rails/controller.rb
@@ -14,8 +14,8 @@ module Stenotype
         #
         def as_json(*_args)
           {
-            class: controller_class.name,
-            method: method,
+            triggered_by_class: controller_class.name,
+            http_method: method,
             url: url,
             referer: referer,
             params: params.except("controller", "action"),

--- a/lib/stenotype/emitter.rb
+++ b/lib/stenotype/emitter.rb
@@ -96,9 +96,9 @@ module Stenotype
           Stenotype::Event.emit!(
             event_name,
             {
-              type: "instance_method",
-              class: self.class.name,
-              method: method.to_sym,
+              triggered_by: "instance_method",
+              triggered_by_class: self.class.name,
+              triggered_by_method: method.to_sym,
               **attributes,
             },
             eval_context: (eval_context || { klass: self })
@@ -123,9 +123,9 @@ module Stenotype
                   # @todo How do we name such events?
                   "instance_method",
                   {
-                    type: "instance_method",
-                    class: self.class.name,
-                    method: __method__,
+                    triggered_by: "instance_method",
+                    triggered_by_class: self.class.name,
+                    triggered_by_method: __method__,
                   },
                   eval_context: { klass: self },
                 )
@@ -147,9 +147,9 @@ module Stenotype
                   # @todo How do we name such events?
                   "class_method",
                   {
-                    type: "class_method",
-                    class: self.name,
-                    method: __method__,
+                    triggered_by: "class_method",
+                    triggered_by_class: self.name,
+                    triggered_by_method: __method__,
                   },
                   eval_context: { klass: self },
                 )

--- a/lib/stenotype/event_serializer.rb
+++ b/lib/stenotype/event_serializer.rb
@@ -43,7 +43,7 @@ module Stenotype
     def serialize
       {
         name: event_name,
-        **event_attributes,
+        **designating_attributes,
         **default_options,
         **eval_context_options,
       }
@@ -59,6 +59,10 @@ module Stenotype
       event.attributes
     end
 
+    def designating_attributes
+      event_attributes.slice(:type, :triggered_by, :triggered_by_class, :triggered_by_method)
+    end
+
     def eval_context
       event.eval_context
     end
@@ -66,7 +70,7 @@ module Stenotype
     def eval_context_options
       context_attributes = eval_context.map do |context_name, context|
         handler = Stenotype::ContextHandlers.known.choose(handler_name: context_name)
-        handler.new(context).as_json
+        handler.new(context, options: event_attributes).as_json
       end
       context_attributes.reduce(:merge!) || {}
     end

--- a/spec/stenotype/context_handlers/base_spec.rb
+++ b/spec/stenotype/context_handlers/base_spec.rb
@@ -33,4 +33,26 @@ RSpec.describe Stenotype::ContextHandlers::Base do
       end
     end
   end
+
+  describe "#method_missing" do
+    let(:context) { object_double(:context) }
+    let(:options) { { symbol_key: :value, "string_key" => "value" } }
+    subject(:dummy_handler_instance) { dummy_handler_class.new(context, options: options) }
+
+    context "when a key is present in options" do
+      it "fetches the value from options" do
+        expect(dummy_handler_instance.symbol_key).to eq(:value)
+      end
+
+      it "does not depend on whether key is string or symbol" do
+        expect(dummy_handler_instance.string_key).to eq("value")
+      end
+    end
+
+    context "when a key is not present in options" do
+      it "raises" do
+        expect { dummy_handler_instance.missing_key }.to raise_error(NoMethodError)
+      end
+    end
+  end
 end

--- a/spec/stenotype/context_handlers/rails/active_job_spec.rb
+++ b/spec/stenotype/context_handlers/rails/active_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Stenotype::ContextHandlers::Rails::ActiveJob do
   describe "#as_json", type: :with_frozen_time do
     it "casts active job data to JSON" do
       expect(context_handler.as_json).to eq(
-        class: :DummyJob,
+        triggered_by_class: :DummyJob,
         job_id: "job id",
         enqueued_at: Time.now.utc,
         queue_name: "default",

--- a/spec/stenotype/context_handlers/rails/controller_spec.rb
+++ b/spec/stenotype/context_handlers/rails/controller_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Stenotype::ContextHandlers::Rails::Controller do
 
     let(:expected_result) do
       {
-        class: "DummyController",
+        triggered_by_class: "DummyController",
         ip: "0.0.0.0",
-        method: "GET",
+        http_method: "GET",
         params: {},
         referer: nil,
         url: "http://test.host/",

--- a/spec/stenotype/emitter_spec.rb
+++ b/spec/stenotype/emitter_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
       let(:expected_event_data) do
         {
           name: "manual_event",
-          class: "DummyKlass",
-          method: :emit_manually,
+          triggered_by_class: "DummyKlass",
+          triggered_by_method: :emit_manually,
           timestamp: Time.now.utc,
-          type: "instance_method",
+          triggered_by: "instance_method",
           uuid: "abcd",
         }
       end
@@ -77,10 +77,10 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
       let(:expected_event_data) do
         {
           name: "aliased",
-          class: "DummyKlass",
-          method: :to_be_aliased,
+          triggered_by_class: "DummyKlass",
+          triggered_by_method: :to_be_aliased,
           timestamp: Time.now.utc,
-          type: "instance_method",
+          triggered_by: "instance_method",
           uuid: "abcd",
         }
       end
@@ -103,9 +103,9 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
       let(:expected_event_data) do
         {
           name: "instance_method",
-          type: "instance_method",
-          class: "DummyKlass",
-          method: :some_method,
+          triggered_by: "instance_method",
+          triggered_by_class: "DummyKlass",
+          triggered_by_method: :some_method,
           timestamp: Time.now.utc,
           uuid: "abcd",
         }
@@ -122,9 +122,9 @@ RSpec.describe Stenotype::Emitter, type: :with_frozen_time do
       let(:expected_event_data) do
         {
           name: "class_method",
-          type: "class_method",
-          class: "DummyKlass",
-          method: :some_class_method,
+          triggered_by: "class_method",
+          triggered_by_class: "DummyKlass",
+          triggered_by_method: :some_class_method,
           timestamp: Time.now.utc,
           uuid: "abcd",
         }

--- a/spec/stenotype/event_serializer_spec.rb
+++ b/spec/stenotype/event_serializer_spec.rb
@@ -6,7 +6,16 @@ RSpec.describe Stenotype::EventSerializer do
   subject(:serializer) { described_class.new(event, uuid_generator: Stenotype::TestUuidGen) }
 
   let(:event_name) { "event_name" }
-  let(:data) { { data_key: "data value" } }
+  let(:data) do
+    {
+      data_key: "data value",
+      type: :custom,
+      triggered_by_class: "SomeClass",
+      triggered_by: "something",
+      triggered_by_method: "some_method",
+      custom_attribute: "custom_attribute",
+    }
+  end
   let(:eval_context) { { klass: dummy_context.new } }
 
   let(:event) do
@@ -23,10 +32,17 @@ RSpec.describe Stenotype::EventSerializer do
     it "represents an event as a hash" do
       expect(serializer.serialize).to eq(
         name: event_name,
-        **data,
+        type: :custom,
+        triggered_by_class: "SomeClass",
+        triggered_by: "something",
+        triggered_by_method: "some_method",
         timestamp: Time.now.utc,
         uuid: "abcd",
       )
+    end
+
+    it "merges only designating attributes from additional attrs" do
+      expect(serializer.serialize).to_not have_key(:custom_attribute)
     end
   end
 end

--- a/spec/stenotype/frameworks/rails/action_controller_extension_spec.rb
+++ b/spec/stenotype/frameworks/rails/action_controller_extension_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe Stenotype::Frameworks::Rails::ActionControllerExtension do
       let(:expected_result) do
         {
           name: "view",
-          class: "DummyController",
+          triggered_by_class: "DummyController",
           ip: "0.0.0.0",
-          method: "GET",
+          http_method: "GET",
           params: {},
           referer: nil,
           timestamp: Time.now.utc,
@@ -131,9 +131,9 @@ RSpec.describe Stenotype::Frameworks::Rails::ActionControllerExtension do
     let(:expected_result) do
       {
         name: "view",
-        class: "DummyController",
+        triggered_by_class: "DummyController",
         ip: "0.0.0.0",
-        method: "GET",
+        http_method: "GET",
         params: {},
         referer: nil,
         timestamp: Time.now.utc,

--- a/spec/stenotype/frameworks/rails/active_job_extension_spec.rb
+++ b/spec/stenotype/frameworks/rails/active_job_extension_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Stenotype::Frameworks::Rails::ActiveJobExtension do
       job_id: "uuid",
       queue_name: "default",
       uuid: "abcd",
-      class: "DummyJob",
+      triggered_by_class: "DummyJob"
     }
   end
 


### PR DESCRIPTION
…ability to refer to additional attributes as to regular methods via method_missing.

Addresses https://github.com/Freshly/stenotype/issues/17