### PR TITLE
Adds config options to explicitly initialize adapter state. Add after…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 *Release Date*: 2020/01/13
 
+### 0.1.7 2020/01/20
+* Adds a config option to allow explicit adapter setup.
+* Adds an `after_initialize` rails hook to setup adapters.
+* Remove topic from the list of Google Cloud adapter arguments.
+
+### 0.1.6 2020/01/17
+* Allow topic to be explicitly set upon Google Cloud adapter initialization
+
 ### 0.1.5 2020/01/13
 * In case `graceful_error_handling` is set to off raise a generic `Stenotype::Error` on any exception in order to intercept a single error type in the client code.
 * Adds an `at_exit` hook to flush the async message queue when using the library in async mode.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stenotype (0.1.3)
+    stenotype (0.1.6)
       activesupport (>= 5.0.0)
       google-cloud-pubsub (~> 1.0.0)
       spicery (>= 0.19.0, < 1.0)

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Stenotype.configure do |config|
     Stenotype::Adapters::GoogleCloud.new
   ]
 
-  config.uuid_generator                 = SecureRandom
-  config.dispatcher                     = Stenotype::Dispatcher.new
-  config.logger                         = Logger.new(STDOUT)
-  config.graceful_error_handling        = true
-  config.explicit_client_initialization = true
+  config.uuid_generator               = SecureRandom
+  config.dispatcher                   = Stenotype::Dispatcher.new
+  config.logger                       = Logger.new(STDOUT)
+  config.graceful_error_handling      = true
+  config.auto_adapter_initialization  = true
 
   config.google_cloud do |gc_config|
     gc_config.project_id  = "google_cloud_project_id"
@@ -66,10 +66,6 @@ Specifies a logger for messages and exceptions to be output to. If not set defau
 #### config.graceful_error_handling
 
 This flag if set to `true` is going to suppress all `StandardError`'s raised within a gem. Raises the error to the caller if set to `false`
-
-#### config.explicit_client_initialization
-
-Allows to enable/disable explicitly setup the adapter. For example client and topic for google cloud.
 
 #### config.uuid_generator
 
@@ -102,6 +98,10 @@ Allows to enable/disable Rails ActionController extension
 #### config.rails.enable_active_job_ext
 
 Allows to enable/disable Rails ActiveJob extension
+
+#### config.rails.auto_adapter_initialization
+
+Controls whether the hook `auto_initialize!` is run for each adapter. If set to true `auto_initialize!` is invoked for every adapter. If false `auto_initialize!` is not run. For example for google cloud adapter this will instantiate `client` and `topic` objects before first publish. If set to false `client` and `topic` are lazy initialized.
 
 #### Configuring context handlers
 
@@ -238,7 +238,7 @@ class CustomAdapter < Stenotype::Adapters::Base
     # actions to be taken to flush the messages
   end
 
-  def setup!
+  def auto_initialize!
     # actions to be taken to setup internal adapter state (client, endpoint, whatsoever)
   end
 end

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Stenotype.configure do |config|
     Stenotype::Adapters::GoogleCloud.new
   ]
 
-  config.uuid_generator          = SecureRandom
-  config.dispatcher              = Stenotype::Dispatcher.new
-  config.logger                  = Logger.new(STDOUT)
-  config.graceful_error_handling = true
+  config.uuid_generator                 = SecureRandom
+  config.dispatcher                     = Stenotype::Dispatcher.new
+  config.logger                         = Logger.new(STDOUT)
+  config.graceful_error_handling        = true
+  config.explicit_client_initialization = true
 
   config.google_cloud do |gc_config|
     gc_config.project_id  = "google_cloud_project_id"
@@ -65,6 +66,10 @@ Specifies a logger for messages and exceptions to be output to. If not set defau
 #### config.graceful_error_handling
 
 This flag if set to `true` is going to suppress all `StandardError`'s raised within a gem. Raises the error to the caller if set to `false`
+
+#### config.explicit_client_initialization
+
+Allows to enable/disable explicitly setup the adapter. For example client and topic for google cloud.
 
 #### config.uuid_generator
 
@@ -227,6 +232,14 @@ class CustomAdapter < Stenotype::Adapters::Base
 
   def publish(event_data, **additional_arguments)
     # custom publishing logic
+  end
+
+  def flush!
+    # actions to be taken to flush the messages
+  end
+
+  def setup!
+    # actions to be taken to setup internal adapter state (client, endpoint, whatsoever)
   end
 end
 ```

--- a/lib/stenotype/adapters/base.rb
+++ b/lib/stenotype/adapters/base.rb
@@ -43,6 +43,14 @@ module Stenotype
       end
 
       #
+      # Allows custom setup of the adapter. Noop by default
+      # @abstract
+      #
+      def setup!
+        # noop by default
+      end
+
+      #
       # This method is expected to be implemented by subclasses. In case async
       # publisher is used the process might end before the async queue of
       # messages is processed, so this method is going to be used in a

--- a/lib/stenotype/adapters/base.rb
+++ b/lib/stenotype/adapters/base.rb
@@ -46,7 +46,7 @@ module Stenotype
       # Allows custom setup of the adapter. Noop by default
       # @abstract
       #
-      def setup!
+      def auto_initialize!
         # noop by default
       end
 

--- a/lib/stenotype/adapters/google_cloud.rb
+++ b/lib/stenotype/adapters/google_cloud.rb
@@ -34,12 +34,6 @@ module Stenotype
     #   end
     #
     class GoogleCloud < Base
-      attr_reader :topic
-
-      def initialize(client: nil, topic: nil)
-        super(client: client)
-        @topic = topic
-      end
       #
       # @param event_data {Hash} The data to be published to Google Cloud
       # @raise {Stenotype::MessageNotPublishedError} unless message is published
@@ -70,6 +64,16 @@ module Stenotype
         return unless topic.async_publisher
 
         topic.async_publisher.stop.wait!
+      end
+
+      #
+      # If not called both client and topic are lazy initialized on first call (if not
+      # passed to #initialize). #setup! is going to explicitly initialize
+      # both client and topic.
+      #
+      def setup!
+        client
+        topic
       end
 
       private

--- a/lib/stenotype/adapters/google_cloud.rb
+++ b/lib/stenotype/adapters/google_cloud.rb
@@ -68,10 +68,10 @@ module Stenotype
 
       #
       # If not called both client and topic are lazy initialized on first call (if not
-      # passed to #initialize). #setup! is going to explicitly initialize
+      # passed to #initialize). #auto_initialize! is going to explicitly initialize
       # both client and topic.
       #
-      def setup!
+      def auto_initialize!
         client
         topic
       end

--- a/lib/stenotype/adapters/stdout_adapter.rb
+++ b/lib/stenotype/adapters/stdout_adapter.rb
@@ -47,6 +47,13 @@ module Stenotype
         # noop
       end
 
+      #
+      # Does nothing
+      #
+      def setup!
+        # noop
+      end
+
       private
 
       def client

--- a/lib/stenotype/adapters/stdout_adapter.rb
+++ b/lib/stenotype/adapters/stdout_adapter.rb
@@ -47,13 +47,6 @@ module Stenotype
         # noop
       end
 
-      #
-      # Does nothing
-      #
-      def setup!
-        # noop
-      end
-
       private
 
       def client

--- a/lib/stenotype/at_exit.rb
+++ b/lib/stenotype/at_exit.rb
@@ -1,6 +1,8 @@
-require 'stenotype'
+# frozen_string_literal: true
 
 # :nocov:
+require "stenotype"
+
 at_exit do
   targets = Stenotype.config.targets
   targets.each(&:flush!)

--- a/lib/stenotype/configuration.rb
+++ b/lib/stenotype/configuration.rb
@@ -35,6 +35,9 @@ module Stenotype
     # @!attribute enabled
     # @return {true, false} a flag indicating whether event emission is enabled
 
+    # @!attribute explicit_client_initialization
+    # @return {true, false} enables/disables lazy initialization of adapters' clients
+
     # @!attribute targets
     # @return {Array<#publish>} a list of targets responding to method [#publish]
 
@@ -58,7 +61,6 @@ module Stenotype
 
     # @!attribute [rw] google_cloud.async
     # @return [true, false] GC publish mode, either async if true, sync if false
-
 
     # @!attribute [rw] rails
     # @return [NestedConfiguration] Rails configuration.
@@ -87,6 +89,7 @@ module Stenotype
       nested :rails do
         option :enable_action_controller_ext, default: true
         option :enable_active_job_ext, default: true
+        option :explicit_client_initialization, default: true
       end
     end
 
@@ -110,6 +113,7 @@ module Stenotype
     #
     def logger
       return config.logger if config.logger
+
       config.logger || Logger.new(STDOUT)
     end
 

--- a/lib/stenotype/configuration.rb
+++ b/lib/stenotype/configuration.rb
@@ -35,7 +35,7 @@ module Stenotype
     # @!attribute enabled
     # @return {true, false} a flag indicating whether event emission is enabled
 
-    # @!attribute explicit_client_initialization
+    # @!attribute auto_adapter_initialization
     # @return {true, false} enables/disables lazy initialization of adapters' clients
 
     # @!attribute targets
@@ -89,7 +89,7 @@ module Stenotype
       nested :rails do
         option :enable_action_controller_ext, default: true
         option :enable_active_job_ext, default: true
-        option :explicit_client_initialization, default: true
+        option :auto_adapter_initialization, default: true
       end
     end
 

--- a/lib/stenotype/event.rb
+++ b/lib/stenotype/event.rb
@@ -24,12 +24,12 @@ module Stenotype
         event = new(name, attributes, eval_context: eval_context, dispatcher: dispatcher)
         event.emit!
         event
-      rescue => error
+      rescue StandardError => exception
         #
         # @todo This is a temporary solution to enable conditional logger fetching
         #   needs a fix to use default Spicerack::Configuration functionality
         #
-        Stenotype::Configuration.logger.error(error)
+        Stenotype::Configuration.logger.error(exception)
 
         raise Stenotype::Error unless Stenotype.config.graceful_error_handling
       end
@@ -68,12 +68,12 @@ module Stenotype
 
       begin
         dispatcher.publish(self)
-      rescue => error
+      rescue StandardError => exception
         #
         # @todo This is a temporary solution to enable conditional logger fetching
         #   needs a fix to use default Spicerack::Configuration functionality
         #
-        Stenotype::Configuration.logger.error(error)
+        Stenotype::Configuration.logger.error(exception)
 
         raise Stenotype::Error unless Stenotype.config.graceful_error_handling
       end

--- a/lib/stenotype/railtie.rb
+++ b/lib/stenotype/railtie.rb
@@ -18,7 +18,7 @@ module Stenotype
 
     config.stenotype = Stenotype.config
 
-    config.after_initialize { config.stenotype.targets.each(&:setup!) } if config.stenotype.rails.explicit_client_initialization
+    config.after_initialize { config.stenotype.targets.each(&:auto_initialize!) } if config.stenotype.rails.auto_adapter_initialization
 
     if config.stenotype.rails.enable_action_controller_ext
       ActiveSupport.on_load(:action_controller) do

--- a/lib/stenotype/railtie.rb
+++ b/lib/stenotype/railtie.rb
@@ -18,6 +18,8 @@ module Stenotype
 
     config.stenotype = Stenotype.config
 
+    config.after_initialize { config.stenotype.targets.each(&:setup!) } if config.stenotype.rails.explicit_client_initialization
+
     if config.stenotype.rails.enable_action_controller_ext
       ActiveSupport.on_load(:action_controller) do
         Stenotype::ContextHandlers.register Stenotype::ContextHandlers::Rails::Controller

--- a/spec/stenotype/adapters/base_spec.rb
+++ b/spec/stenotype/adapters/base_spec.rb
@@ -56,4 +56,29 @@ RSpec.describe Stenotype::Adapters::Base do
       end
     end
   end
+
+  describe "#setup!" do
+    subject(:setup!) { klass_instance.setup! }
+
+    context "when not implemented" do
+      it "does nothing" do
+        expect(setup!).to eq(nil)
+      end
+    end
+
+    context "when a subclass implements method #setup!" do
+      before do
+        klass.class_eval do
+          def setup!
+            # do nothing
+            true
+          end
+        end
+      end
+
+      it "setups the adapter" do
+        expect(setup!).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/stenotype/adapters/base_spec.rb
+++ b/spec/stenotype/adapters/base_spec.rb
@@ -57,19 +57,19 @@ RSpec.describe Stenotype::Adapters::Base do
     end
   end
 
-  describe "#setup!" do
-    subject(:setup!) { klass_instance.setup! }
+  describe "#auto_initialize!" do
+    subject(:auto_initialize!) { klass_instance.auto_initialize! }
 
     context "when not implemented" do
       it "does nothing" do
-        expect(setup!).to eq(nil)
+        expect(auto_initialize!).to eq(nil)
       end
     end
 
-    context "when a subclass implements method #setup!" do
+    context "when a subclass implements method #auto_initialize!" do
       before do
         klass.class_eval do
-          def setup!
+          def auto_initialize!
             # do nothing
             true
           end
@@ -77,7 +77,7 @@ RSpec.describe Stenotype::Adapters::Base do
       end
 
       it "setups the adapter" do
-        expect(setup!).to eq(true)
+        expect(auto_initialize!).to eq(true)
       end
     end
   end

--- a/spec/stenotype/adapters/google_cloud_spec.rb
+++ b/spec/stenotype/adapters/google_cloud_spec.rb
@@ -102,12 +102,12 @@ RSpec.describe Stenotype::Adapters::GoogleCloud do
     end
   end
 
-  describe "#setup!" do
-    let(:setup!) { adapter.setup! }
+  describe "#auto_initialize!" do
+    let(:auto_initialize!) { adapter.auto_initialize! }
 
     context "when a client is passed" do
       it "sets up client and topic" do
-        expect { setup! }.not_to change { adapter.instance_variable_get(:@client) }
+        expect { auto_initialize! }.not_to change { adapter.instance_variable_get(:@client) }
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe Stenotype::Adapters::GoogleCloud do
         expect(adapter.instance_variable_get(:@client)).to eq(nil)
         expect(adapter.instance_variable_get(:@topic)).to eq(nil)
 
-        setup!
+        auto_initialize!
 
         expect(adapter.instance_variable_get(:@client)).to eq(fake_client_double)
         expect(adapter.instance_variable_get(:@topic)).to eq(topic_double)

--- a/spec/stenotype/adapters/google_cloud_spec.rb
+++ b/spec/stenotype/adapters/google_cloud_spec.rb
@@ -23,9 +23,16 @@ RSpec.describe Stenotype::Adapters::GoogleCloud do
     end
   end
 
+  let(:fake_publisher) do
+    Class.new do
+      def stop; end
+      def wait!; end
+    end
+  end
+
+  let(:fake_publisher_double) { instance_double(fake_publisher, wait!: true) }
   let(:topic_double) { instance_double(fake_topic, publish: true, publish_async: true) }
   let(:fake_client_double) { instance_double(fake_client, topic: topic_double) }
-
   let(:adapter) { described_class.new(client: fake_client_double) }
 
   describe "#publish" do
@@ -68,20 +75,12 @@ RSpec.describe Stenotype::Adapters::GoogleCloud do
   end
 
   describe "#flush!" do
-    let(:fake_publisher) do
-      Class.new do
-        def stop; end
-        def wait!; end
-      end
-    end
-
     subject(:flush!) { adapter.flush! }
-    let(:fake_publisher_double) { instance_double(fake_publisher, wait!: true) }
 
     context "when async_publisher is not initialized" do
       before { allow(topic_double).to receive(:async_publisher).and_return(nil) }
 
-      it 'does nothing' do
+      it "does nothing" do
         expect(flush!).to eq(nil)
         expect(topic_double).to have_received(:async_publisher).once
       end
@@ -93,12 +92,38 @@ RSpec.describe Stenotype::Adapters::GoogleCloud do
         allow(topic_double).to receive(:async_publisher).and_return(fake_publisher_double)
       end
 
-      it 'stops the publisher' do
+      it "stops the publisher" do
         flush!
 
         expect(topic_double).to have_received(:async_publisher).twice
         expect(fake_publisher_double).to have_received(:stop).once
         expect(fake_publisher_double).to have_received(:wait!).once
+      end
+    end
+  end
+
+  describe "#setup!" do
+    let(:setup!) { adapter.setup! }
+
+    context "when a client is passed" do
+      it "sets up client and topic" do
+        expect { setup! }.not_to change { adapter.instance_variable_get(:@client) }
+      end
+    end
+
+    context "when a client is not passed" do
+      let(:adapter) { described_class.new }
+
+      before { allow(Google::Cloud::PubSub).to receive(:new).and_return(fake_client_double) }
+
+      it "setup client and topic" do
+        expect(adapter.instance_variable_get(:@client)).to eq(nil)
+        expect(adapter.instance_variable_get(:@topic)).to eq(nil)
+
+        setup!
+
+        expect(adapter.instance_variable_get(:@client)).to eq(fake_client_double)
+        expect(adapter.instance_variable_get(:@topic)).to eq(topic_double)
       end
     end
   end

--- a/spec/stenotype/adapters/stdout_adapter_spec.rb
+++ b/spec/stenotype/adapters/stdout_adapter_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe Stenotype::Adapters::StdoutAdapter do
     end
   end
 
-  describe "#setup!" do
-    subject(:setup!) { adapter.setup! }
+  describe "#auto_initialize!" do
+    subject(:auto_initialize!) { adapter.auto_initialize! }
 
     it "does nothing" do
-      expect(setup!).to eq(nil)
+      expect(auto_initialize!).to eq(nil)
     end
   end
 end

--- a/spec/stenotype/adapters/stdout_adapter_spec.rb
+++ b/spec/stenotype/adapters/stdout_adapter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Stenotype::Adapters::StdoutAdapter do
 
   describe "#publish" do
     subject(:publish) { adapter.publish(event_data, additional_arguments) }
+
     before { allow(client_double).to receive(:info).and_yield }
 
     it "publishes the message to STDOUT" do
@@ -23,8 +24,16 @@ RSpec.describe Stenotype::Adapters::StdoutAdapter do
   describe "#flush!" do
     subject(:flush!) { adapter.flush! }
 
-    it 'does nothing' do
+    it "does nothing" do
       expect(flush!).to eq(nil)
+    end
+  end
+
+  describe "#setup!" do
+    subject(:setup!) { adapter.setup! }
+
+    it "does nothing" do
+      expect(setup!).to eq(nil)
     end
   end
 end

--- a/spec/stenotype/configuration_spec.rb
+++ b/spec/stenotype/configuration_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe Stenotype::Configuration, type: :configuration do
   it { is_expected.to define_config_option :logger }
 
   nested_config_option :rails do
-    it { is_expected.to define_config_option(:enable_action_controller_ext, default: true) }
-    it { is_expected.to define_config_option(:enable_active_job_ext, default: true) }
-    it { is_expected.to define_config_option :explicit_client_initialization, default: true }
+    it { is_expected.to define_config_option :enable_action_controller_ext, default: true }
+    it { is_expected.to define_config_option :enable_active_job_ext, default: true }
+    it { is_expected.to define_config_option :auto_adapter_initialization, default: true }
   end
 
   nested_config_option :google_cloud do

--- a/spec/stenotype/configuration_spec.rb
+++ b/spec/stenotype/configuration_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe Stenotype::Configuration, type: :configuration do
     end
   end
 
-  describe '.logger' do
+  describe ".logger" do
     subject(:logger) { configuration.logger }
 
-    context 'when logger is not set' do
+    context "when logger is not set" do
       before { Stenotype.configure { |config| config.logger = nil } }
 
       it { is_expected.to be_instance_of(Logger) }
     end
 
-    context 'when a custom logger is set' do
+    context "when a custom logger is set" do
       let(:custom_logger_klass) { Class.new(Logger) }
       let(:logger_io) { custom_logger_klass.new(STDOUT) }
 
@@ -54,6 +54,7 @@ RSpec.describe Stenotype::Configuration, type: :configuration do
   nested_config_option :rails do
     it { is_expected.to define_config_option(:enable_action_controller_ext, default: true) }
     it { is_expected.to define_config_option(:enable_active_job_ext, default: true) }
+    it { is_expected.to define_config_option :explicit_client_initialization, default: true }
   end
 
   nested_config_option :google_cloud do

--- a/spec/stenotype/event_spec.rb
+++ b/spec/stenotype/event_spec.rb
@@ -60,23 +60,22 @@ RSpec.describe Stenotype::Event do
       end
     end
 
-    context 'when exception is raised' do
+    context "when exception is raised" do
       subject(:emit_event) { described_class.emit!("some_event", *{ key: :value }) }
 
       let(:logger_double) { instance_double(Logger, error: true) }
-      before { allow(Stenotype::Event).to receive(:new).and_raise(StandardError.new('boom')) }
 
-      context 'when graceful exception handling is enabled' do
+      before { allow(described_class).to receive(:new).and_raise(StandardError.new("boom")) }
+
+      context "when graceful exception handling is enabled" do
         before { Stenotype.configure { |config| config.logger = logger_double } }
 
-        it 'handles error' do
-          expect {
-            emit_event
-          }.to_not raise_error
+        it "handles error" do
+          expect { emit_event }.not_to raise_error
         end
       end
 
-      context 'when graceful exception handling is disabled' do
+      context "when graceful exception handling is disabled" do
         before do
           Stenotype.configure do |config|
             config.logger = logger_double
@@ -86,10 +85,8 @@ RSpec.describe Stenotype::Event do
 
         after { Stenotype.configure { |config| config.graceful_error_handling = true } }
 
-        it 'raises error' do
-          expect {
-            emit_event
-          }.to raise_error(Stenotype::Error)
+        it "raises error" do
+          expect { emit_event }.to raise_error(Stenotype::Error)
         end
       end
     end
@@ -125,21 +122,20 @@ RSpec.describe Stenotype::Event do
       end
     end
 
-    context 'when exception is raised' do
+    context "when exception is raised" do
       let(:logger_double) { instance_double(Logger, error: true) }
-      before { allow(test_dispatcher).to receive(:publish).and_raise(StandardError.new('boom')) }
 
-      context 'when graceful exception handling is enabled' do
+      before { allow(test_dispatcher).to receive(:publish).and_raise(StandardError.new("boom")) }
+
+      context "when graceful exception handling is enabled" do
         before { Stenotype.configure { |config| config.logger = logger_double } }
 
-        it 'handles error' do
-          expect {
-            event.emit!
-          }.to_not raise_error
+        it "handles error" do
+          expect { event.emit! }.not_to raise_error
         end
       end
 
-      context 'when graceful exception handling is disabled' do
+      context "when graceful exception handling is disabled" do
         before do
           Stenotype.configure do |config|
             config.logger = logger_double
@@ -149,10 +145,8 @@ RSpec.describe Stenotype::Event do
 
         after { Stenotype.configure { |config| config.graceful_error_handling = true } }
 
-        it 'raises error' do
-          expect {
-            event.emit!
-          }.to raise_error(Stenotype::Error)
+        it "raises error" do
+          expect { event.emit! }.to raise_error(Stenotype::Error)
         end
       end
     end


### PR DESCRIPTION
… initialize rails hook to setup adapters. Fixes rubocop warnings. Removes topic from the list of google cloud adapter arguments.