### PR TITLE
LUPA-963 bump google-cloud-pubsub from 1.0.0 to 1.10.0

### DIFF
--- a/stenotype.gemspec
+++ b/stenotype.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport", ">= 5.0.0"
-  spec.add_dependency "google-cloud-pubsub", "~> 1.0.0"
+  spec.add_dependency "google-cloud-pubsub", "~> 1.10.0"
 
   spec.add_runtime_dependency "spicery", ">= 0.22.0", "< 1.0"
 


### PR DESCRIPTION
bump google-cloud-pubsub from 1.0.0 to 1.10.0
we need it for Ruby 3 support